### PR TITLE
feat: add rate limiter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
-CMD ["./bin/rails", "server"]
+CMD ["./bin/rails", "server", "-b", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,6 @@ gem 'rspec-rails', '~> 6.1'
 gem 'rswag', '~> 2.13'
 
 gem 'jwt', '~> 2.8'
+
+# Use Rack::Attack to throttle and block abusive requests [https://github.com/rack/rack-attack]
+gem 'rack-attack', '~> 6.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.0)
     rack (3.1.3)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-session (2.0.0)
@@ -328,6 +330,7 @@ DEPENDENCIES
   net-pop!
   pg (~> 1.1)
   puma (>= 5.0)
+  rack-attack (~> 6.7.0)
   rack-cors
   rails (~> 7.1.3, >= 7.1.3.4)
   redis (>= 4.0.1)

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,8 @@ module Split
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # Enable Rack::Attack middleware for limiting requests
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,6 +27,13 @@ Rails.application.configure do
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
+  elsif ENV['RAILS_DEV_CACHE'] == 'true'
+    config.action_controller.perform_caching = true
+    config.cache_store = :memory_store
+    config.public_file_server.headers = {
+      'Cache-Control' => "public, max-age=#{2.days.seconds.to_i}"
+    }
+ 
   else
     config.action_controller.perform_caching = false
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,20 @@
+class Rack::Attack
+
+  # throttle request to 100 requests per 5 minutes
+  throttle('req/ip', limit: 100, period: 5.minutes) do |req|
+    if req.path.start_with?('/assets') # Ignore assets requests
+      req.ip
+    end
+  end
+
+
+  # Ban IPs that are making too many requests in a short period of time
+  # Ban if user login 10 times in 1 minute, for 5 minutes
+  Rack::Attack.blocklist('blocklist') do |req|
+    Rack::Attack::Allow2Ban.filter(req.ip, maxretry: 10, findtime: 1.minute, bantime: 5.minutes) do
+      if req.path == '/login' && req.post?
+        req.ip
+      end
+    end
+  end
+end

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,33 @@
+# A docker-compose for ruby on rails development environment
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db 
+    environment:
+      - DATABASE_URL=postgresql://postgres:password@db:5432/app_development
+      - SECRET_KEY_BASE=secret_key_base
+      - RAILS_ENV=development
+      - ENABLE_RACK_ATTACK=true
+      - RAILS_DEV_CACHE=true
+
+  db:
+    image: postgres:14
+    volumes:
+      - db:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: app_development
+
+volumes:
+  db:
+    driver: local

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,5 @@
+## Run Development Environment with Docker Compose
+
+```bash
+docker compose -f docker-compose.dev.yml up
+```


### PR DESCRIPTION
- Add `rack_attack` as a rate limiter.
- Add `config/initializers/rack_attack.rb` for `rack_attack`.
  - Allow2Ban: Ban a user if they attempt to log in 10 times within 1 minute, for 5 minutes.
  - Throttle: Limit requests to 100 requests per 5 minutes, exclude assets requests.
- Add a `docker-compose` file including a PostgreSQL service to simplify building a local development environment.


- Host the web server on `0.0.0.0` in the Docker container, allowing access via localhost.
- Change the RubyCache control condition. Now, you can enable the cache in development by setting the environment variable `RAILS_DEV_CACHE` to true.

Please note that the Dockerfile hosts the server on `0.0.0.0`. I am not sure how this will affect the deployment on Zeabur.